### PR TITLE
Initialize columns search settings

### DIFF
--- a/website/display_dictionary.js
+++ b/website/display_dictionary.js
@@ -28,6 +28,7 @@ $(document).ready(function() {
       // At first, only show English
       if (language != "EN"){
         conf["visible"] = false;
+        conf["searchable"] = false;
       }
       columnsConf.push(conf);
     });


### PR DESCRIPTION
At the moment [columns searchable](searchable) inital settings are all default `true`.
I forgot to initialize this properly in #25.


